### PR TITLE
Add update siteTittle in AtoM read-only feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,8 @@ All variables which can be overridden are stored in [defaults/main.yml](defaults
 | `atom_replication_synchronize_downloads_dir` | False | Boolean variable that enables the synchronization of the downloads directories |
 | `atom_replication_synchronize_uploads_dir` | False | Boolean variable that enables the synchronization of the uploads directories |
 | `atom_replication_ro_nginx_user` | `{% if ansible_os_family == 'RedHat' %}nginx{% elif ansible_os_family == 'Debian' %}www-data{% endif %}` | Nginx user on the AtoM read-only  server. It is needed to run the php symfony commands |
+| `atom_replication_restore_sitetitle` | False | When variable is set to True the role will change the siteTitle on the read-only database, using the `atom_replication_ro_sitetitle` value |
+| `atom_replication_ro_sitetitle` | Read Only Site | String used as siteTitle in the setting_i18n table (read-only database) when `atom_replication_restore_sitetitle=True` |
 | `atom_replication_synchronize_baseurl` | False | When not using the read-only base URL on the edit AtoM server, setting this variable as `True` the role will change the base URL on read-only site on all files in the downloads directory |
 | `atom_replication_edit_dnsname` | http://edit.accesstomemory.org/ | String that will be replaced by the `atom_replication_ro_dnsname` string on the AtoM read-only downloads files when `atom_replication_synchronize_baseurl=True` |
 | `atom_replication_ro_dnsname` | http://ro.accesstomemory.org/ | String that replaces the `atom_replication_edit_dnsname` string on the AtoM read-only downloads files when `atom_replication_synchronize_baseurl=True` |

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -109,6 +109,11 @@ atom_replication_synchronize_downloads_dir: False
 # Nginx users
 atom_replication_ro_nginx_user: "{% if ansible_os_family == 'RedHat' %}nginx{% elif ansible_os_family == 'Debian' %}www-data{% endif %}"
 
+# Restore Site Title in read-only AtoM (Optional)
+# Check running: "select * from setting_i18n where id=189;" in both databases
+atom_replication_restore_sitetitle: False
+atom_replication_ro_sitetitle: "Read Only Site"
+
 # Synchronize baseurl (Optional)
 # Check running: "select value from setting_i18n where id='124';" in both databases
 atom_replication_synchronize_baseurl: False

--- a/tasks/atom-restore-sitetitle.yml
+++ b/tasks/atom-restore-sitetitle.yml
@@ -1,0 +1,24 @@
+---
+
+- name: "Get siteTitle id from setting and setting_i18n"
+  become: "yes"
+  mysql_query:
+    login_db: "{{ atom_replication_ro_db_name }}"
+    login_unix_socket: "{{ atom_replication_ro_mysql_unix_socket }}"
+    query:
+      - SELECT s.id FROM setting s INNER JOIN setting_i18n si ON s.id=si.id AND s.name='siteTitle'
+  register: __siteTitle_id
+  when:
+   - inventory_hostname == atom_replication_ro_mysql_host|string
+
+- name: "Use read-only siteTitle"
+  become: "yes"
+  mysql_query:
+    login_db: "{{ atom_replication_ro_db_name }}"
+    login_unix_socket: "{{ atom_replication_ro_mysql_unix_socket }}"
+    query:
+      - UPDATE setting_i18n SET value='{{ atom_replication_ro_sitetitle }}' WHERE id=%s AND culture='en'
+    positional_args:
+      - "{{ __siteTitle_id.query_result[0][0].id }}"
+  when:
+   - inventory_hostname == atom_replication_ro_mysql_host|string

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -142,6 +142,13 @@
 
 ## Replication Post Actions
 
+- import_tasks: "atom-restore-sitetitle.yml"
+  when:
+    - atom_replication_restore_sitetitle|bool
+    # host limitation conditional in playbook tasks
+  tags:
+    - "atom-restore-sitetitle"
+
 - import_tasks: "atom-sync-baseurl.yml"
   when:
     - atom_replication_synchronize_baseurl|bool


### PR DESCRIPTION
Connects to https://github.com/artefactual-labs/ansible-atom-replication/issues/6

The following 2 variables have been added:

* atom_replication_ro_sitetitle
* atom_replication_restore_sitetittle (default False)

When `atom_replication_restore_sitetittle` is set as True, the `atom_replication_ro_sitetitle` value is used as Read-Only AtoM Title