### PR TITLE
Add nginx start/stop to avoid open index in es-restore-backup

### DIFF
--- a/tasks/es-restore-backup.yml
+++ b/tasks/es-restore-backup.yml
@@ -28,6 +28,11 @@
     group: "{{ atom_replication_snapshot_es_group }}"
     remote_src: true
 
+- name: "Temporarily stop nginx (to prevent index reopening)"
+  service:
+    name: nginx
+    state: stopped
+
 - name: "Close index to avoid problems while restoring the backup on ES read-only server"
   uri:
     url: "http://127.0.0.1:{{ atom_replication_es_port }}/{{ atom_replication_ro_es_index }}/_close"
@@ -51,3 +56,8 @@
   uri:
     url: "http://127.0.0.1:{{ atom_replication_es_port }}/{{ atom_replication_ro_es_index }}/_open"
     method: "POST"
+
+- name: "Start nginx after index restore"
+  service:
+    name: nginx
+    state: started


### PR DESCRIPTION
Add task to stop nginx before closing index to prevent it from reopening, causing error on "Restore ES snapshot":

```
backup-repo:backup-repo/g-D8ci8OQJuCL11QG4zuxg] cannot restore index because it's open",
"type": "snapshot_restore_exception"}], "type": "snapshot_restore_exception"}, "status": 500}, 
"msg": "Status code was 500 and not [200]: HTTP Error 500: Internal Server Error", 
"redirected": false, "status": 500, "url": "http://127.0.0.1:9200/_snapshot/backup-repo/backup-repo/_restore?wait_for_completion=true"}
``` 