### PR TITLE
Update host template for different user scenario

### DIFF
--- a/templates/hosts.j2
+++ b/templates/hosts.j2
@@ -1,6 +1,6 @@
 {% for host in __dict_hosts %}
 {%   if host.ansible_host == atom_replication_ansible_remote_server -%}
-{{ host.ansible_host }}	ansible_connection=local
+{{ host.ansible_host }}	ansible_connection=local ansible_ssh_user={{ host.ansible_ssh_username }}
 {%   else -%}
 {{ host.ansible_host }}	ansible_ssh_host={{ host.ansible_ssh_hostname }} ansible_host={{ host.ansible_ssh_hostname }} ansible_ssh_user={{ host.ansible_ssh_username }}
 {%   endif %}


### PR DESCRIPTION
Otherwise getting undefined for ansible_ssh_user at:

```
TASK [artefactual.atom-replication : create tarball of the ES repo] ************

FAILED! => {"msg": "The task includes an option with an undefined variable. The error was: 'ansible_ssh_user' is undefined\n\nThe error appears to be in '/usr/share/nginx/atom-replication/roles/artefactual.atom-replication/tasks/es-backup.yml': line 27, column 3, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n\n- name: \"create tarball of the ES repo\"\n  ^ here\n"}
```