### PR TITLE
Add AtoM 2.9 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ The OS tested are:
 * Ubuntu 18
 * Ubuntu 20
 * CentOS 7
+* Rocky 9
 
 You need ansible >= 2.10. The recommended version is 2.12.5. It is because the role uses the `mysql_query` module and it doesn't exist in ansible<=2.9. The following collections must be installed:
 
@@ -127,6 +128,7 @@ All variables which can be overridden are stored in [defaults/main.yml](defaults
 | `atom_replication_ansible_remote_cron_file` | replicate-atom | Cron job filename to run the replication script. When using more than one replication script in the same `ansible-run-server`, please ensure it is different for every script. Only used when `atom_replication_ansible_remote_cron_enabled=True` |
 | `atom_replication_ansible_remote_cron_mailto` | | Email address to sent the replication script output. Only used when `atom_replication_ansible_remote_cron_enabled=True` |
 | `atom_replication_es_port` | 9200 | Elasticsearch tcp port used to connect to both elasticsearch servers |
+| `atom_replication_es_multiple_indices` | False | Boolean variable that must be True in AtoM >= 2.9 (because AtoM >= 2.9 uses multiple indices) |
 | `atom_replication_edit_es_base_url_schema` | http | Base url schema for edit elasticsearch url |
 | `atom_replication_ro_es_base_url_schema` | http | Base url schema for read-only elasticsearch url |
 | `atom_replication_edit_es_base_url_host` | 127.0.0.1 | Base url host for edit elasticsearch url |
@@ -151,6 +153,7 @@ All variables which can be overridden are stored in [defaults/main.yml](defaults
 |`atom_replication_ro_uploads_path` | `{{ atom_replication_ro_path }}/uploads/` | Uploads directory on read-only AtoM server, this is the destination on the synchronization from the edit AtoM server uploads directory when `atom_replication_synchronize_uploads_dir=True`. This variable always must end in "/" character |
 | `atom_replication_synchronize_downloads_dir` | False | Boolean variable that enables the synchronization of the downloads directories |
 | `atom_replication_synchronize_uploads_dir` | False | Boolean variable that enables the synchronization of the uploads directories |
+| `atom_replication_nginx_stop_service` | True | Boolean variable that stops nginx service, don't set as False when AtoM < 2.9. Must be 'True' in AtoM < 2.9 to avoid problems when restoring elasticsearch indice (any request can open the index and replication fails) |
 | `atom_replication_ro_nginx_user` | `{% if ansible_os_family == 'RedHat' %}nginx{% elif ansible_os_family == 'Debian' %}www-data{% endif %}` | Nginx user on the AtoM read-only  server. It is needed to run the php symfony commands |
 | `atom_replication_restore_sitetitle` | False | When variable is set to True the role will change the siteTitle on the read-only database, using the `atom_replication_ro_sitetitle` value |
 | `atom_replication_ro_sitetitle` | Read Only Site | String used as siteTitle in the setting_i18n table (read-only database) when `atom_replication_restore_sitetitle=True` |
@@ -263,6 +266,23 @@ For more details see the following 3 sample scenarios:
 1. [Single Server with all services and two AtoM sites](documentation/single-server-scenario.md)
 2. [Two servers with their own nginx, elasticsearch and MySQL services and a site on every server](documentation/two-servers-scenario.md)
 3. [Three servers: nginx server with the two AtoM sites, a MySQL server for both sites and an Elasticsearch server for both sites](documentation/three-servers-scenario.md)
+
+
+AtoM 2.9 Support
+----------------
+
+Note that AtoM 2.9 added changes in Elasticsearch. It uses multiple indices instead of a single index, please make sure you set:
+
+```
+atom_replication_es_multiple_indices: True
+```
+
+And optionally (by default the role will stop the nginx service), you can disable the nginx service stop when running the role with:
+
+```
+atom_replication_nginx_stop_service: False
+```
+
 
 License
 -------

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -76,6 +76,7 @@ atom_replication_ro_es_base_url_host: "127.0.0.1"
 atom_replication_edit_es_base_url: "{{ atom_replication_edit_es_base_url_schema }}://{{ atom_replication_edit_es_base_url_host }}"
 atom_replication_ro_es_base_url: "{{ atom_replication_ro_es_base_url_schema }}://{{ atom_replication_ro_es_base_url_host }}"
 
+# AtoM indices or indices prefixes for AtoM >= 2.9
 atom_replication_edit_es_index: "atom-edit"
 atom_replication_ro_es_index: "atom-ro"
 
@@ -83,6 +84,9 @@ atom_replication_es_repo_name: "backup-repo"
 atom_replication_es_snapshot_name: "backup-repo"
 
 atom_replication_es_backup_repo_path: "/var/lib/elasticsearch/backup-repo"
+
+# AtoM >= 2.9 use multiple indices instead a single one
+atom_replication_es_multiple_indices: False
 
 # MySQL settings
 atom_replication_edit_db_name: "atom-edit"
@@ -114,6 +118,12 @@ atom_replication_ro_uploads_path: "{{ atom_replication_ro_path }}/uploads/"
 # AtoM synchronize uploads and downloads directories with rsync (Optional)
 atom_replication_synchronize_uploads_dir: False
 atom_replication_synchronize_downloads_dir: False
+
+# Nginx settings
+
+# In AtoM >= 2.9 nginx stop can be skipped because ES indices are not opened in every AtoM query
+# You can set False to skip nginx stop
+atom_replication_nginx_stop_service: True
 
 # Nginx users
 atom_replication_ro_nginx_user: "{% if ansible_os_family == 'RedHat' %}nginx{% elif ansible_os_family == 'Debian' %}www-data{% endif %}"

--- a/tasks/abort-replication.yml
+++ b/tasks/abort-replication.yml
@@ -22,6 +22,7 @@
     state: "restarted"
   when:
     - inventory_hostname == atom_replication_ro_atom_host|string
+    - atom_replication_nginx_stop_service|bool
 
 - name: "Send abort signal when some task has failed"
   shell: /bin/false

--- a/tasks/es-backup.yml
+++ b/tasks/es-backup.yml
@@ -13,7 +13,7 @@
     owner: "{{ atom_replication_snapshot_es_user }}"
     group: "{{ atom_replication_snapshot_es_group }}"
 
-- name: "Take atom index snapshot on ES edit server"
+- name: "Take atom index snapshot on ES edit server - Single index"
   uri:
     url: "{{ atom_replication_edit_es_base_url }}:{{ atom_replication_es_port }}/_snapshot/{{ atom_replication_es_repo_name }}/{{ atom_replication_es_snapshot_name }}?wait_for_completion=true"
     method: "PUT"
@@ -23,6 +23,21 @@
     body_format: "json"
     timeout: 600
     use_proxy: false
+  when:
+    - not atom_replication_es_multiple_indices|bool
+
+- name: "Take atom index snapshot on ES edit server - Multiple indices"
+  uri:
+    url: "{{ atom_replication_edit_es_base_url }}:{{ atom_replication_es_port }}/_snapshot/{{ atom_replication_es_repo_name }}/{{ atom_replication_es_snapshot_name }}?wait_for_completion=true"
+    method: "PUT"
+    body:
+      indices: "{{ __indices_string_edit }}"
+      ignore_unavailable: "true"
+    body_format: "json"
+    timeout: 600
+    use_proxy: false
+  when:
+    - atom_replication_es_multiple_indices|bool
 
 - name: "create tarball of the ES repo"
   archive:

--- a/tasks/es-clone-index-multiple.yml
+++ b/tasks/es-clone-index-multiple.yml
@@ -1,0 +1,81 @@
+---
+
+- name: "Delete read-only indices"
+  uri:
+    url: "{{ atom_replication_edit_es_base_url }}:{{ atom_replication_es_port }}/{{ atom_replication_ro_es_index }}_{{ item }}"
+    method: "DELETE"
+    use_proxy: false
+  ignore_errors: True
+  loop: "{{ __indices_suffix_list }}"
+
+- name: "Install curl and jq packages on elasticsearch server"
+  become: "yes"
+  package:
+    name:
+      - curl
+      - jq
+    state: "present"
+
+- name: "Get the edit indices mapping"
+  shell: 
+    curl -s {{ atom_replication_edit_es_base_url }}:{{ atom_replication_es_port }}/{{ atom_replication_edit_es_index }}_{{ item }} | jq '."{{ atom_replication_edit_es_index }}_{{ item }}" | del(.settings.index.provided_name, .settings.index.creation_date, .settings.index.uuid, .settings.index.version)' 
+  register: "__edit_es_index_mapping"
+  loop: "{{ __indices_suffix_list }}"
+
+- name: "Create the read-only indices with the edit mapping"
+  uri:
+    url: "{{ atom_replication_ro_es_base_url }}:{{ atom_replication_es_port }}/{{ atom_replication_ro_es_index }}_{{ item }}"
+    headers:
+      Content-Type: "application/json"
+    method: "PUT"
+    body_format: "json"
+    body: "{{ (__edit_es_index_mapping.results | selectattr('item', 'equalto', item) | map(attribute='stdout') | first) | from_json }}"
+    use_proxy: false
+  loop: "{{ __indices_suffix_list }}"
+
+- name: "Disable ES replication and refresh interval, tune translog on read-only index"
+  uri:
+    url: "{{ atom_replication_edit_es_base_url }}:{{ atom_replication_es_port }}/{{ atom_replication_ro_es_index }}_{{ item }}/_settings"
+    headers:
+      Content-Type: "application/json"
+    method: "PUT"
+    body_format: "json"
+    body:
+      number_of_replicas: 0
+      refresh_interval: -1
+      translog.durability: "async"
+      translog.flush_threshold_size: "1024MB"
+    use_proxy: false
+  loop: "{{ __indices_suffix_list }}"
+
+- name: "Reindex the edit indices on the new read-only indices"
+  uri:
+    url: "{{ atom_replication_edit_es_base_url }}:{{ atom_replication_es_port }}/_reindex"
+    timeout: 3600
+    headers:
+      Content-Type: "application/json"
+    method: "POST"
+    body_format: "json"
+    body:
+      conflicts: "proceed"
+      source:
+        index: "{{ atom_replication_edit_es_index }}_{{ item }}"
+        size: 10000
+      dest:
+        index: "{{ atom_replication_ro_es_index }}_{{ item }}"
+    use_proxy: false
+  loop: "{{ __indices_suffix_list }}"
+
+- name: "Restore default values on read-only index"
+  uri:
+    url: "{{ atom_replication_edit_es_base_url }}:{{ atom_replication_es_port }}/{{ atom_replication_ro_es_index }}_{{ item }}/_settings"
+    headers:
+      Content-Type: "application/json"
+    method: "PUT"
+    body_format: "json"
+    body:
+      refresh_interval: null
+      translog.durability: "request"
+      translog.flush_threshold_size: "512MB"
+    use_proxy: false
+  loop: "{{ __indices_suffix_list }}"

--- a/tasks/es-restore-backup.yml
+++ b/tasks/es-restore-backup.yml
@@ -28,14 +28,27 @@
     group: "{{ atom_replication_snapshot_es_group }}"
     remote_src: true
 
-- name: "Close index to avoid problems while restoring the backup on ES read-only server"
+- name: "Close index to avoid problems while restoring the backup on ES read-only server - Single Index"
   uri:
     url: "{{ atom_replication_ro_es_base_url }}:{{ atom_replication_es_port }}/{{ atom_replication_ro_es_index }}/_close"
     method: "POST"
     use_proxy: false
   ignore_errors: yes   # Fails when the index doesn't exist
+  when:
+    - not atom_replication_es_multiple_indices|bool
 
-- name: "Restore ES snapshot"
+- name: "Close indices to avoid problems while restoring the backup on ES read-only server - Multiple Indices"
+  uri:
+    url: "{{ atom_replication_ro_es_base_url }}:{{ atom_replication_es_port }}/{{ atom_replication_ro_es_index }}_{{ item }}/_close"
+    method: "POST"
+    use_proxy: false
+  ignore_errors: yes   # Fails when the index doesn't exist
+  loop: "{{ __indices_suffix_list }}"
+  when:
+    - atom_replication_es_multiple_indices|bool
+
+
+- name: "Restore ES snapshot - Single Index"
   uri:
     url: "{{ atom_replication_ro_es_base_url }}:{{ atom_replication_es_port }}/_snapshot/{{ atom_replication_es_repo_name }}/{{ atom_replication_es_snapshot_name }}/_restore?wait_for_completion=true"
     method: POST
@@ -48,9 +61,43 @@
     body_format: "json"
     timeout: 1800
     use_proxy: false
+  when:
+    - not atom_replication_es_multiple_indices|bool
 
-- name: "Open ES index on ES read-only server"
+# See: 
+# https://www.elastic.co/docs/reference/elasticsearch/curator/option_rename_replacement
+# https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-snapshot-restore
+# Restore all edit indices renaming the index prefix to the read-only one
+- name: "Restore ES snapshot - Multiple Indices"
+  uri:
+    url: "{{ atom_replication_ro_es_base_url }}:{{ atom_replication_es_port }}/_snapshot/{{ atom_replication_es_repo_name }}/{{ atom_replication_es_snapshot_name }}/_restore?wait_for_completion=true"
+    method: POST
+    body:
+      indices: "{{ __indices_string_edit }}"
+      rename_pattern: "{{ atom_replication_edit_es_index }}(.+)" # Get all after atom_replication_edit_es_index prefix ans save as $1
+      ignore_unavailable: false
+      include_global_state: false
+      rename_replacement: "{{ atom_replication_ro_es_index }}$1" # Rename atom_replication_edit_es_index prefix with the atom_replication_ro_es_index prefix
+    body_format: "json"
+    timeout: 1800
+    use_proxy: false
+  when:
+    - atom_replication_es_multiple_indices|bool
+
+
+- name: "Open ES index on ES read-only server - Single index"
   uri:
     url: "{{ atom_replication_ro_es_base_url }}:{{ atom_replication_es_port }}/{{ atom_replication_ro_es_index }}/_open"
     method: "POST"
     use_proxy: false
+  when:
+    - not atom_replication_es_multiple_indices|bool
+
+- name: "Open ES indices on ES read-only server - Multiple indices"
+  uri:
+    url: "{{ atom_replication_ro_es_base_url }}:{{ atom_replication_es_port }}/{{ atom_replication_ro_es_index }}_{{ item }}/_open"
+    method: "POST"
+    use_proxy: false
+  loop: "{{ __indices_suffix_list }}"
+  when:
+    - atom_replication_es_multiple_indices|bool

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,6 +1,12 @@
 ---
 # tasks file for atom-replication-role
 
+- name: "Ensure atom_replication_os_packages are installed in all hosts"
+  become: "yes"
+  package:
+    name: "{{ atom_replication_os_packages }}"
+    state: present
+
 - name: "Email notification: Define playbook status"
   set_fact:
     _playbook_status: "ERROR"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -47,6 +47,7 @@
     - "restart nginx"
   when:
     - inventory_hostname == atom_replication_ro_atom_host|string
+    - atom_replication_nginx_stop_service|bool
   tags:
     - "es-clone-index"
     - "es-ro-restore"
@@ -57,7 +58,9 @@
   become: "yes"
   wait_for:
     timeout: 60
-  when: inventory_hostname == atom_replication_ro_atom_host | string
+  when:
+    - inventory_hostname == atom_replication_ro_atom_host | string
+    - atom_replication_nginx_stop_service|bool
   tags:
     - "es-clone-index"
     - "es-ro-restore"
@@ -100,11 +103,21 @@
   tags:
     - "always"
 
-# When edit and ro indices in the same ES server
+# When edit and ro indices in the same ES server --> just clone indices
 - import_tasks: "es-clone-index.yml"
   when:
     - inventory_hostname == atom_replication_edit_es_host|string
     - atom_replication_edit_es_host|string == atom_replication_ro_es_host|string
+    - not atom_replication_es_multiple_indices|bool
+  tags:
+    - "es-clone-index"
+    - "es-ro-restore"
+
+- import_tasks: "es-clone-index-multiple.yml"
+  when:
+    - inventory_hostname == atom_replication_edit_es_host|string
+    - atom_replication_edit_es_host|string == atom_replication_ro_es_host|string
+    - atom_replication_es_multiple_indices|bool
   tags:
     - "es-clone-index"
     - "es-ro-restore"
@@ -203,6 +216,7 @@
     state: "started"
   when:
     - inventory_hostname == atom_replication_edit_atom_host|string
+    - atom_replication_nginx_stop_service|bool
 
 ## Set playbook status for email notification
 - name: "Email notification: Set playbook status as SUCCESS"

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -13,3 +13,8 @@ __indices_suffix_list:
 __indices_string_edit: "{{ atom_replication_edit_es_index }}_qubitactor,{{ atom_replication_edit_es_index }}_qubitrepository,{{ atom_replication_edit_es_index }}_qubitaip,{{ atom_replication_edit_es_index }}_qubitaccession,{{ atom_replication_edit_es_index }}_qubitfunctionobject,{{ atom_replication_edit_es_index }}_qubitinformationobject,{{ atom_replication_edit_es_index }}_qubitterm"
 
 __indices_string_ro: "{{ atom_replication_ro_es_index }}_qubitactor,{{ atom_replication_ro_es_index }}_qubitrepository,{{ atom_replication_ro_es_index }}_qubitaip,{{ atom_replication_ro_es_index }}_qubitaccession,{{ atom_replication_ro_es_index }}_qubitfunctionobject,{{ atom_replication_ro_es_index }}_qubitinformationobject,{{ atom_replication_ro_es_index }}_qubitterm"
+
+atom_replication_os_packages:
+  - "rsync"
+  - "tar"
+  - "unzip"

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,2 +1,15 @@
 ---
 # vars file for atom-replication-role
+
+__indices_suffix_list:
+  - "qubitactor"
+  - "qubitrepository"
+  - "qubitaip"
+  - "qubitaccession"
+  - "qubitfunctionobject"
+  - "qubitinformationobject"
+  - "qubitterm"
+
+__indices_string_edit: "{{ atom_replication_edit_es_index }}_qubitactor,{{ atom_replication_edit_es_index }}_qubitrepository,{{ atom_replication_edit_es_index }}_qubitaip,{{ atom_replication_edit_es_index }}_qubitaccession,{{ atom_replication_edit_es_index }}_qubitfunctionobject,{{ atom_replication_edit_es_index }}_qubitinformationobject,{{ atom_replication_edit_es_index }}_qubitterm"
+
+__indices_string_ro: "{{ atom_replication_ro_es_index }}_qubitactor,{{ atom_replication_ro_es_index }}_qubitrepository,{{ atom_replication_ro_es_index }}_qubitaip,{{ atom_replication_ro_es_index }}_qubitaccession,{{ atom_replication_ro_es_index }}_qubitfunctionobject,{{ atom_replication_ro_es_index }}_qubitinformationobject,{{ atom_replication_ro_es_index }}_qubitterm"


### PR DESCRIPTION
Add changes needed to support AtoM 2.9. Main changes:

* using multiple elasticsearch indices
* nginx service doesn't need to be stopped when AtoM >=9

New variables have been added to the role:

* `atom_replication_es_multiple_indices`: Must be set as True when AtoM >=2.9 (default:False)
* `atom_replication_nginx_stop_service` : Allows to skip the nginx service stop when running the replication

Added a task to install rsync, tar and unzip packages in all hosts.

The README.md file has been updated.

