### PR TITLE
Reduce ES cloning batch size in multi-index

### DIFF
--- a/tasks/es-clone-index-multiple.yml
+++ b/tasks/es-clone-index-multiple.yml
@@ -60,7 +60,7 @@
       conflicts: "proceed"
       source:
         index: "{{ atom_replication_edit_es_index }}_{{ item }}"
-        size: 10000
+        size: 500
       dest:
         index: "{{ atom_replication_ro_es_index }}_{{ item }}"
     use_proxy: false


### PR DESCRIPTION
The change is only needed when ES version >= 7 because the new variable in elasticsearch with the default value:

indexing_pressure.memory.limit: 10%

Using a batch size of 500 instead of 1000 will reduce the memory usage when reindexing (cloning) the index.