### PR TITLE
Add atom_replication_es_clone_timeout variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ All variables which can be overridden are stored in [defaults/main.yml](defaults
 | `atom_replication_ansible_remote_cron_file` | replicate-atom | Cron job filename to run the replication script. When using more than one replication script in the same `ansible-run-server`, please ensure it is different for every script. Only used when `atom_replication_ansible_remote_cron_enabled=True` |
 | `atom_replication_ansible_remote_cron_mailto` | | Email address to sent the replication script output. Only used when `atom_replication_ansible_remote_cron_enabled=True` |
 | `atom_replication_es_port` | 9200 | Elasticsearch tcp port used to connect to both elasticsearch servers |
+| `atom_replication_es_clone_timeout` | 3600 | Elasticsearch clone timeout in seconds when using the same Elasticsearch server for read-only and edit |
 | `atom_replication_es_multiple_indices` | False | Boolean variable that must be True in AtoM >= 2.9 (because AtoM >= 2.9 uses multiple indices) |
 | `atom_replication_edit_es_base_url_schema` | http | Base url schema for edit elasticsearch url |
 | `atom_replication_ro_es_base_url_schema` | http | Base url schema for read-only elasticsearch url |

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -68,6 +68,7 @@ atom_replication_ansible_remote_cron_mailto: ""
 
 # Assuming all ES servers are going to use the same port
 atom_replication_es_port: "9200"
+atom_replication_es_clone_timeout: 3600
 
 atom_replication_edit_es_base_url_schema: "http"
 atom_replication_edit_es_base_url_host: "127.0.0.1"

--- a/tasks/es-clone-index-multiple.yml
+++ b/tasks/es-clone-index-multiple.yml
@@ -51,7 +51,7 @@
 - name: "Reindex the edit indices on the new read-only indices"
   uri:
     url: "{{ atom_replication_edit_es_base_url }}:{{ atom_replication_es_port }}/_reindex"
-    timeout: 3600
+    timeout: "{{ atom_replication_es_clone_timeout | default(3600) }}"
     headers:
       Content-Type: "application/json"
     method: "POST"

--- a/tasks/es-clone-index.yml
+++ b/tasks/es-clone-index.yml
@@ -47,7 +47,7 @@
 - name: "Reindex the edit index on the new read-only index"
   uri:
     url: "{{ atom_replication_edit_es_base_url }}:{{ atom_replication_es_port }}/_reindex"
-    timeout: 3600
+    timeout: "{{ atom_replication_es_clone_timeout | default(3600) }}"
     headers:
       Content-Type: "application/json"
     method: "POST"


### PR DESCRIPTION
When cloning ES indices, the hardcoded 3600 seconds could not be enough for large indices.

The `atom_replication_es_clone_timeout` variable has been added to allow to set a timeout greater than 3600 seconds.

Connects to https://github.com/artefactual-labs/ansible-atom-replication/issues/25